### PR TITLE
fix barebones.html issue with Emmy

### DIFF
--- a/barebones.html
+++ b/barebones.html
@@ -28,7 +28,16 @@
          state_advancer.call(null,harmonic_state_derivative,2.0,1.0);
 
      try {
-         harmonic_state_advancer.call(null, up01, 10.0, 1.0e-12);
+         const opts = cljs.core.hash_map.call(
+           null,
+           cljs.core.keyword.call(null, "epsilon"),
+           1.0e-12,
+           cljs.core.keyword.call(null, "compile?"),
+           true
+         );
+         document.body.append(
+           harmonic_state_advancer.call(null, up01, 10.0, opts)
+         );
      } catch (error) {
          document.body.append(error);
          // TypeError: Cannot mix BigInt and other types, use explicit conversions


### PR DESCRIPTION
Hi @kloimhardt ! Looks like the issue is that Emmy wasn't compiling the derivatives by default, so a `BigInt` was getting produced somewhere and breaking the ODE solver.

This patch should fix things, and then over at Emmy I'm going to enable compilation by default:

https://github.com/mentat-collective/emmy/pull/134

I'll get that shipped in version 0.30.1, or you can ignore this patch and use the following git dependency for now:

```clj
io.github.mentat-collective/emmy
{:git/sha "7fac677d014639ef52bdbb57d81999458c48c911"}
```

Cheers!